### PR TITLE
Bump Junit version to 4.13.1 to address security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bump Junit version to 4.13.1 to address TemporaryFolder on unix-like systems does not limit access to created files vulnerability